### PR TITLE
Changed DebuggerDisplay to fix issue with null values.

### DIFF
--- a/src/Models/Client.cs
+++ b/src/Models/Client.cs
@@ -15,11 +15,13 @@ namespace IdentityServer4.Models
     /// <summary>
     /// Models an OpenID Connect or OAuth2 client
     /// </summary>
-    [DebuggerDisplay("{ClientId}")]
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Client
     {
         // setting grant types should be atomic
         private ICollection<string> _allowedGrantTypes = new GrantTypeValidatingHashSet();
+
+        private string DebuggerDisplay => ClientId ?? $"{{{typeof(Client)}}}";
 
         /// <summary>
         /// Specifies if client is enabled (defaults to <c>true</c>)
@@ -63,7 +65,7 @@ namespace IdentityServer4.Models
         /// URI to further information about client (used on consent screen)
         /// </summary>
         public string ClientUri { get; set; }
-        
+
         /// <summary>
         /// URI to client logo (used on consent screen)
         /// </summary>
@@ -130,7 +132,7 @@ namespace IdentityServer4.Models
         /// Specifies is the user's session id should be sent to the FrontChannelLogoutUri. Defaults to <c>true</c>.
         /// </summary>
         public bool FrontChannelLogoutSessionRequired { get; set; } = true;
-        
+
         /// <summary>
         /// Specifies logout URI at client for HTTP back-channel based logout.
         /// </summary>
@@ -336,11 +338,11 @@ namespace IdentityServer4.Models
             {
                 throw new InvalidOperationException("Grant types list contains duplicate values");
             }
-            
+
             // would allow response_type downgrade attack from code to token
             DisallowGrantTypeCombination(GrantType.Implicit, GrantType.AuthorizationCode, grantTypes);
             DisallowGrantTypeCombination(GrantType.Implicit, GrantType.Hybrid, grantTypes);
-            
+
             DisallowGrantTypeCombination(GrantType.AuthorizationCode, GrantType.Hybrid, grantTypes);
         }
 

--- a/src/Models/Resource.cs
+++ b/src/Models/Resource.cs
@@ -10,9 +10,11 @@ namespace IdentityServer4.Models
     /// <summary>
     /// Models the common data of API and identity resources.
     /// </summary>
-    [DebuggerDisplay("{Name}")]
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract class Resource
     {
+        private string DebuggerDisplay => Name ?? $"{{{typeof(Resource)}}}";
+
         /// <summary>
         /// Indicates if this resource is enabled. Defaults to true.
         /// </summary>

--- a/src/Models/Scope.cs
+++ b/src/Models/Scope.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -12,9 +12,11 @@ namespace IdentityServer4.Models
     /// <summary>
     /// Models access to an API resource
     /// </summary>
-    [DebuggerDisplay("{Name}")]
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Scope
     {
+        private string DebuggerDisplay => Name ?? $"{{{typeof(Scope)}}}";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Scope"/> class.
         /// </summary>


### PR DESCRIPTION
This PR fixes issue with debugger display of null values. Below is an example what happens when the `ClientId` of a `Client` is empty:

![image](https://user-images.githubusercontent.com/10426229/46673257-aae0c880-cbd9-11e8-8e04-fa8f9a5f5896.png)

When going through the code in something like a unit test where we don't need to set the value of `ClientId` for our test to work it displays null which is really confusing. Maybe this should be fixed inside VisualStudio but this PR makes some changes that will change it to display the following:

![image](https://user-images.githubusercontent.com/10426229/46673728-b97baf80-cbda-11e8-997d-e186b0f12a33.png)

We only had this issue with the `Client` class but if I have also patched the other classes with a `DebuggerDisplayAttribute`.