### PR TITLE
IPassiveable interface added.

### DIFF
--- a/src/Interfaces/IPassiveable.cs
+++ b/src/Interfaces/IPassiveable.cs
@@ -1,0 +1,16 @@
+namespace IdentityServer4.Storage.Interfaces
+{
+    /// <summary>
+    /// Represents if the entity is capable of being active/passive
+    /// </summary>
+    public interface IPassiveable
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is active.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is active; otherwise, <c>false</c>.
+        /// </value>
+        bool Active { get; set; }
+    }
+}


### PR DESCRIPTION
The interface is intended to determine if entity is active or passive for entities that can support active/passive state, like User entity on Asp.Net Core Identity.

The placement of the interface can differ, it just seemed here was more convenient.